### PR TITLE
Adds an option 'type' for data or schema only dumps

### DIFF
--- a/tasks/lib/mysqldump.js
+++ b/tasks/lib/mysqldump.js
@@ -118,7 +118,7 @@ module.exports = function (grunt) {
           host: options.host,
           port: options.port,
           dest: path,
-		      type: options.type!='both'?(options.type=='schema'?'-d':(options.type=='data'?'--no-create-info':'')):''
+          type: options.type!='both'?(options.type=='schema'?'-d':(options.type=='data'?'--no-create-info':'')):''
         }
       });
 

--- a/tasks/lib/mysqldump.js
+++ b/tasks/lib/mysqldump.js
@@ -110,14 +110,15 @@ module.exports = function (grunt) {
 
       grunt.file.mkdir(folder);
 
-      var cmd = grunt.template.process("mysqldump -h <%= host %> -P <%= port %> -u <%= user %> <%= pass %> <%= database %> -r <%= dest %>", {
+      var cmd = grunt.template.process("mysqldump -h <%= host %> -P <%= port %> -u <%= user %> <%= pass %> <%= type %> <%= database %> -r <%= dest %>", {
         data: {
           user: options.user,
           pass: '--password="' + options.pass + '"',
           database: file,
           host: options.host,
           port: options.port,
-          dest: path
+          dest: path,
+		      type: options.type!='both'?(options.type=='schema'?'-d':(options.type=='data'?'--no-create-info':'')):''
         }
       });
 

--- a/tasks/mysqldump.js
+++ b/tasks/mysqldump.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
       host: config.host,
       port: config.port,
       dest: config.dest,
+      type: config.type,
       compress: false,
       algorithm: 'zip',
       level: 1,


### PR DESCRIPTION
Adds an option 'type' for data or schema only dumps.

Possible values: 'data', 'schema', 'both'. Default: 'both'.

Basically adds '-d', '--no-create-info' or nothing to the mysqldump command.